### PR TITLE
Make Card Update functional with new dropdown

### DIFF
--- a/src/components/Feature/CardCreate.js
+++ b/src/components/Feature/CardCreate.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { withRouter } from 'react-router-dom'
 import axios from 'axios'
-import ListGroup from 'react-bootstrap/ListGroup'
+// import ListGroup from 'react-bootstrap/ListGroup'
 import apiUrl from '../../apiConfig'
 import CardForm from './CardForm'
 import messages from '../AutoDismissAlert/messages'
@@ -15,7 +15,7 @@ const CardCreate = props => {
   useEffect(() => {
     axios(`${apiUrl}/decks`)
       .then(res => {
-        console.log(res.data.decks)
+        // console.log(res.data.decks)
         setDecks(res.data.decks)
       })
       // .then(res => (console.log('decks are', res.data.decks)))
@@ -31,13 +31,13 @@ const CardCreate = props => {
 
   // console.log('deckIds are', deckIds)
 
-  const deckList = decks.map(deck => {
+  /* const deckList = decks.map(deck => {
     return (
       <ListGroup.Item key={deck.id}>
         Deck ID: {deck.id} Deck Subject: {deck.subject}
       </ListGroup.Item>
     )
-  })
+  }) */
 
   const handleChange = event => {
     event.persist()
@@ -83,10 +83,10 @@ const CardCreate = props => {
         handleSubmit={handleSubmit}
         cancelPath={'/decks'}
       />
-      <div>
+      { /*  <div>
         <h5>Available Deck IDs and Subjects</h5>
         {deckList}
-      </div>
+      </div> */ }
     </div>
   )
 }

--- a/src/components/Feature/CardForm.js
+++ b/src/components/Feature/CardForm.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import Button from 'react-bootstrap/Button'
 
-const CardForm = ({ card, decks, option, handleChange, handleSubmit, cancelPath }) => (
+const CardForm = ({ card, option, handleChange, handleSubmit, cancelPath }) => (
   <form onSubmit={handleSubmit}>
     <label htmlFor="question">Question</label>
     <textarea
@@ -24,28 +24,11 @@ const CardForm = ({ card, decks, option, handleChange, handleSubmit, cancelPath 
       onChange={handleChange}
     />
 
-    { /* console.log('decks are', decks) */ }
-
     <select name="deck_id" onChange={(event) => handleChange(event)} value={card.deck_id}
     >
       <option>Select a Subject</option>
       {option}
     </select>
-
-    { /* <select name="deck_id" onChange={(event) => handleChange(event)}
-    >
-      <option>Select a Subject</option>
-      {
-        decks.map((deck, index) => {
-          return (
-            <option key={deck.id} value={deck.id} selected={card.deck_id === deck.id} >
-              {deck.subject}
-            </option>
-          )
-        })
-      }
-    </select>
-  */ }
 
     <Button variant={'info'} type="submit">Submit</Button>
     <Link to={cancelPath}>

--- a/src/components/Feature/CardUpdate.js
+++ b/src/components/Feature/CardUpdate.js
@@ -9,6 +9,7 @@ import messages from '../AutoDismissAlert/messages'
 const CardUpdate = props => {
   const [card, setCard] = useState({ question: '', answer: '', deck_id: '' })
   const [editedCard, setEditedCard] = useState(null)
+  const [decks, setDecks] = useState([])
   const { alert } = props
 
   useEffect(() => {
@@ -16,6 +17,22 @@ const CardUpdate = props => {
       .then(res => setCard(res.data.card))
       .catch(console.error)
   }, [])
+
+  useEffect(() => {
+    axios(`${apiUrl}/decks`)
+      .then(res => {
+        setDecks(res.data.decks)
+      })
+      .catch(console.error)
+  }, [])
+
+  const deckIds = decks.map(deck => {
+    return (
+      <option key={deck.id} value={deck.id}>
+        {deck.subject}
+      </option>
+    )
+  })
 
   const handleChange = event => {
     event.persist()
@@ -49,15 +66,14 @@ const CardUpdate = props => {
       })
   }
 
-  console.log('props are', props)
-
   if (editedCard) {
     return <Redirect to={`/decks/${card.deck.id}`} />
   }
   return (
     <CardForm
       card={card}
-      deck={card.deck_id}
+      option={deckIds}
+      // deck={card.deck_id}
       handleChange={handleChange}
       handleSubmit={handleSubmit}
       cancelPath={'/decks'}


### PR DESCRIPTION
1. Add dropdown to CardUpdate, so card's deck may be changed
(note: this still makes an extra API call to decks, like CardCreate)
2. Commented out unnecessary code in CardCreate (old list of Decks and
their IDs)
3. removed all unnecessary code from CardForm, including extra console
logs